### PR TITLE
Dockernize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM yamitzky/miniconda-neologd
+
+WORKDIR /app
+
+# to install mecab-python3
+RUN apt-get update -qq && apt-get install -y build-essential
+
+COPY env.yml /app
+RUN conda env create --file /app/env.yml
+RUN echo 'source activate simstring' > ~/.bashrc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  main:
+    build: .
+    command: bash -c "source activate simstring && python -c 'from time import sleep; sleep(10**5)'"
+    volumes:
+      - .:/app

--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,8 @@
+name: simstring
+channels:
+- defaults
+dependencies:
+- python=3.7.0
+- pip:
+  - mecab-python3
+  - pymongo


### PR DESCRIPTION
MeCabのインストールがローカル環境でうまくいかなかったため、Dockerで開発環境を構築。
mongodbなどもdocker-composesでいれると良さそうだが、一旦MeCabのためだけに構築する。