### PR TITLE
Add overlap measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ print(results)
 - Cosine
 - Dice
 - Jaccard
+- Overlap
 
 ## Run Tests
 ```

--- a/simstring/measure/overlap.py
+++ b/simstring/measure/overlap.py
@@ -1,0 +1,17 @@
+from simstring.measure.base import BaseMeasure
+from sys import maxsize
+import math
+
+class OverlapMeasure(BaseMeasure):
+    def min_feature_size(self, query_size, alpha):
+        return 1
+
+    def max_feature_size(self, query_size, alpha):
+        return maxsize
+
+    def minimum_common_feature_count(self, query_size, y_size, alpha):
+        print(query_size, y_size, alpha)
+        return int(math.ceil(alpha * min(query_size, y_size)))
+
+    def similarity(self, X, Y):
+        return min(len(set(X)), len(set(Y)))

--- a/simstring/measure/overlap.py
+++ b/simstring/measure/overlap.py
@@ -10,7 +10,6 @@ class OverlapMeasure(BaseMeasure):
         return maxsize
 
     def minimum_common_feature_count(self, query_size, y_size, alpha):
-        print(query_size, y_size, alpha)
         return int(math.ceil(alpha * min(query_size, y_size)))
 
     def similarity(self, X, Y):

--- a/simstring/searcher.py
+++ b/simstring/searcher.py
@@ -14,6 +14,8 @@ class Searcher:
         features = self.feature_extractor.features(query_string)
         min_feature_size = self.measure.min_feature_size(len(features), alpha)
         max_feature_size = self.measure.max_feature_size(len(features), alpha)
+        if hasattr(self.db, 'max_feature_size'):
+            max_feature_size = min(max_feature_size, self.db.max_feature_size())
         results = []
 
         for candidate_feature_size in range(min_feature_size, max_feature_size + 1):

--- a/tests/measure/test_overlap.py
+++ b/tests/measure/test_overlap.py
@@ -1,0 +1,30 @@
+# -*- coding:utf-8 -*-
+
+from unittest import TestCase
+from simstring.measure.overlap import OverlapMeasure
+from sys import maxsize
+
+class TestOverlap(TestCase):
+    measure = OverlapMeasure()
+
+    def test_min_feature_size(self):
+        self.assertEqual(self.measure.min_feature_size(5, 1.0), 1)
+        self.assertEqual(self.measure.min_feature_size(5, 0.5), 1)
+
+    def test_max_feature_size(self):
+        self.assertEqual(self.measure.max_feature_size(5, 1.0), maxsize)
+        self.assertEqual(self.measure.max_feature_size(5, 0.5), maxsize)
+
+    def test_minimum_common_feature_count(self):
+        self.assertEqual(self.measure.minimum_common_feature_count(5, 5, 1.0), 5)
+        self.assertEqual(self.measure.minimum_common_feature_count(5, 20, 1.0), 5)
+        self.assertEqual(self.measure.minimum_common_feature_count(5, 5, 0.5), 3)
+
+    def test_similarity(self):
+        x = [1, 2, 3]
+        y = [1, 2, 3, 4]
+        self.assertEqual(round(self.measure.similarity(x, x), 2), 3)
+        self.assertEqual(round(self.measure.similarity(x, y), 2), 3)
+
+        z = [1, 1, 2, 3]
+        self.assertEqual(round(self.measure.similarity(z, z), 2), 3)


### PR DESCRIPTION
One obstacle to implementing Overlap measure is the fact that the original implementation gives max size for that measure as [`INT_MAX`](https://github.com/chokkan/simstring/blob/6209ea86d84f7043f8e19029d83299f458665ec5/include/simstring/measure.h#L137).

To solve this, one can only [restrict this](https://github.com/chokkan/simstring/blob/6209ea86d84f7043f8e19029d83299f458665ec5/include/simstring/simstring.h#L650) at search time.

There may also be a possibility to [implement the max size](https://www.quora.com/How-do-I-find-the-longest-and-shortest-length-of-a-field-among-all-values-for-that-field-in-mongoDb) for mongo, however I've never worked with it and I don't dare touch it without even having it installed. :)